### PR TITLE
Drop quarto from work config

### DIFF
--- a/nix/home/work.nix
+++ b/nix/home/work.nix
@@ -11,10 +11,6 @@
 
   home.stateVersion = "24.05"; # Please read the comment before changing.
 
-  home.packages = [
-    pkgs.quarto
-  ];
-
   home.sessionPath = [
     "/snap/bin"
   ];


### PR DESCRIPTION
Pulled deno (and a slow-from-source V8 rebuild) into the closure
for a tool that wasn't being used.